### PR TITLE
Remove extraneous entry to scss/main.scss

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -16,12 +16,11 @@
 @import "../node_modules/bootstrap/scss/variables-dark";
 
 // 4. Include any default map overrides here
-$btn-disabled-color: green !default;
+
 // 5. Include remainder of required parts
 @import "../node_modules/bootstrap/scss/maps";
 @import "../node_modules/bootstrap/scss/mixins";
 @import "../node_modules/bootstrap/scss/utilities";
-
 
 // 6. Optionally include any other parts as needed
 @import "../node_modules/bootstrap/scss/root";


### PR DESCRIPTION
Remove unneeded and unused reference in scss/main.scss. Does not impact generated CSS files.