### PR TITLE
Add meta robots "noindex, nofollow" to /search with search query text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Application Change Log
 
+## Version 1.0.1
+
+### Application Changes
+
+- Add `<meta name="robots" content="noindex, nofollow">` to `<head>` when there is a search query value parsed by the `/search` route
+
 ## Version 1.0.0
 
 - Promoting version 1.0.0-rc3 to 1.0.0, no application or component changes

--- a/app/templates/core/head.html
+++ b/app/templates/core/head.html
@@ -1,5 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+{% if search_query %}
+<meta name="robots" content="noindex, nofollow">
+{% endif %}
 <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version Module."""
 
-APP_VERSION = "1.0.0"
+APP_VERSION = "1.0.1"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,6 +48,7 @@ def test_search(client: FlaskClient, query: str, mode: int) -> None:
     assert "article" in response.text
     assert "<audio" in response.text
     assert "Clip Info" in response.text
+    assert "noindex, nofollow" in response.text
 
 
 def test_search_no_query(client: FlaskClient) -> None:
@@ -56,6 +57,7 @@ def test_search_no_query(client: FlaskClient) -> None:
     assert response.status_code == 200
     assert "Hey Gurgle" in response.text
     assert "No search query was provided." in response.text
+    assert "noindex, nofollow" not in response.text
 
 
 @pytest.mark.parametrize(
@@ -69,6 +71,7 @@ def test_search_no_results(client: FlaskClient, query: str, mode: int) -> None:
     assert response.status_code == 200
     assert "Hey Gurgle" in response.text
     assert "No search results found for" in response.text
+    assert "noindex, nofollow" in response.text
 
 
 def test_robots_txt(client: FlaskClient) -> None:


### PR DESCRIPTION
## Application Changes

- Add `<meta name="robots" content="noindex, nofollow">` to `<head>` when there is a search query value parsed by the `/search` route