### PR TITLE
Fix clip title not appearing in <title> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Application Change Log
 
+## Version 1.1.1
+
+### Application Changes
+
+- Fixed an issue where the clip title is not included in the HTML `<title>` tag.
+
 ## Version 1.1.0
 
 ### Application Changes

--- a/app/templates/pages/clip.html
+++ b/app/templates/pages/clip.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block page_title %}
-{% if clip_info and "title" in clip_info %}Clip Info: {{ clip_info.title }}{% else %}Clip Info{% endif %} | Hey Gurgle: Marsupial Gurgle Audio Archive Search
+{% if clip and "title" in clip %}Clip Info: {{ clip.title }}{% else %}Clip Info{% endif %} | Hey Gurgle: Marsupial Gurgle Audio Archive Search
 {% endblock page_title %}
 
 {% block content %}

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version Module."""
 
-APP_VERSION = "1.1.0"
+APP_VERSION = "1.1.1"


### PR DESCRIPTION
## Application Changes

- Fixed an issue where the clip title is not included in the HTML `<title>` tag.