### PR TITLE
Upgrade Flask to 3.1.1, update dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Application Change Log
 
+## Version 1.2.7
+
+### Component Changes
+
+- Upgrade Flask from 3.1.0 to 3.1.1
+
+### Development Changes
+
+- Upgrade ruff from 0.9.10 to 0.11.9
+- Upgrade pytest from 8.3.3 to 8.3.5
+- Upgrade pytest-cov from 6.0.0 to 6.1.1
+
 ## Version 1.2.6
 
 ### Application Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version Module."""
 
-APP_VERSION = "1.2.6"
+APP_VERSION = "1.2.7"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-ruff==0.9.10
+ruff==0.11.9
 pytest==8.3.5
-pytest-cov==6.0.0
+pytest-cov==6.1.1
 
-Flask==3.1.0
+Flask==3.1.1
 flask-sanitize-escape==0.0.3
 gunicorn==23.0.0
 mysql-connector-python==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.1.0
+Flask==3.1.1
 flask-sanitize-escape==0.0.3
 gunicorn==23.0.0
 mysql-connector-python==9.1.0


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 3.1.0 to 3.1.1

## Development Changes

- Upgrade ruff from 0.9.10 to 0.11.9
- Upgrade pytest from 8.3.3 to 8.3.5
- Upgrade pytest-cov from 6.0.0 to 6.1.1